### PR TITLE
Replicate browsers' same route navigation behavior

### DIFF
--- a/src/roadtrip.js
+++ b/src/roadtrip.js
@@ -86,7 +86,8 @@ if ( window ) {
 			scrollY: scroll.y,
 			popstate: true, // so we know not to manipulate the history
 			fulfil: noop,
-			reject: noop
+			reject: noop,
+			options: {}
 		};
 
 		_goto( _target );
@@ -108,9 +109,16 @@ function _goto ( target ) {
 		}
 	}
 
-	if ( !newRoute || isSameRoute( newRoute, currentRoute, newData, currentData ) ) {
+	const isSame = isSameRoute( newRoute, currentRoute, newData, currentData );
+	const shouldIgnore = target.options.ignoreSameRoute && isSame;
+
+	if ( !newRoute || shouldIgnore ) {
 		target.fulfil();
 		return;
+	}
+
+	if ( !('replaceState' in target.options) ) {
+		target.options.replaceState = isSame;
 	}
 
 	scrollHistory[ currentID ] = {

--- a/test/tests.js
+++ b/test/tests.js
@@ -265,8 +265,7 @@ describe( 'roadtrip', () => {
 					})
 					.start();
 
-				return roadtrip.start()
-					.then( () => roadtrip.goto( '/foo#baz' ) )
+				return roadtrip.goto( '/foo#baz' )
 					.then( () => {
 						assert.deepEqual( hashes, [
 							'bar',

--- a/test/tests.js
+++ b/test/tests.js
@@ -158,13 +158,11 @@ describe( 'roadtrip', () => {
 			});
 		});
 
-		it( 'treats navigating to the same route as a noop', () => {
-			return createTestEnvironment().then( window => {
+		it( 'does not treat navigating to the same route as a noop', () => {
+			return createTestEnvironment('/foo').then( window => {
 				const roadtrip = window.roadtrip;
 
 				let leftFoo;
-
-				window.location.href += 'foo';
 
 				roadtrip
 					.add( '/foo', {
@@ -175,6 +173,27 @@ describe( 'roadtrip', () => {
 					.start();
 
 				return roadtrip.goto( '/foo' ).then( () => {
+					assert.ok( leftFoo );
+					window.close();
+				});
+			});
+		});
+
+		it( 'treats navigating to the same route as a noop when ignoreSameRoute is set', () => {
+			return createTestEnvironment('/foo').then( window => {
+				const roadtrip = window.roadtrip;
+
+				let leftFoo;
+
+				roadtrip
+					.add( '/foo', {
+						leave () {
+							leftFoo = true;
+						}
+					})
+					.start();
+
+				return roadtrip.goto( '/foo', { ignoreSameRoute: true } ).then( () => {
 					assert.ok( !leftFoo );
 					window.close();
 				});
@@ -296,13 +315,13 @@ describe( 'roadtrip', () => {
 					.start();
 
 				return roadtrip.goto( '/bar' ).then( () => {
-					assert.deepEqual( ids, [
-						'foo',
-						'bar'
-					]);
+						assert.deepEqual( ids, [
+							'foo',
+							'bar'
+						]);
 
-					window.close();
-				});
+						window.close();
+					});
 			});
 		});
 


### PR DESCRIPTION
Browsers do not ignore navigation requests (eg. link clicks) to the current page like roadtrip. Instead, they perform the navigation without creating a new history entry.

This will replicate that behavior, unless `replaceState` or the new `ignoreSameRoute` options are explicitly passed to `goto()`.