### PR TITLE
Change how `start()` works

### DIFF
--- a/src/roadtrip.js
+++ b/src/roadtrip.js
@@ -31,7 +31,7 @@ const roadtrip = {
 		return roadtrip;
 	},
 
-	start ( { fallback } = {} ) {
+	start ( { fallback, dispatch } = {} ) {
 		const href = !fallback || routes.some( route => route.matches( location.href ) ) ?
 			location.href :
 			fallback;
@@ -39,6 +39,7 @@ const roadtrip = {
 		_start();
 
 		return roadtrip.goto( href, {
+			dispatch,
 			replaceState: true,
 			scrollX: window.scrollX,
 			scrollY: window.scrollY
@@ -89,7 +90,8 @@ function _start () {
 				scrollY: scroll.y,
 				popstate: true, // so we know not to manipulate the history
 				fulfil: noop,
-				reject: noop
+				reject: noop,
+				options: {}
 			};
 
 			_goto( _target );
@@ -126,7 +128,9 @@ function _goto ( target ) {
 
 	let promise;
 
-	if ( ( newRoute === currentRoute ) && newRoute.updateable ) {
+	if ( target.options.dispatch === false ) {
+		promise = roadtrip.Promise.resolve();
+	} else if ( ( newRoute === currentRoute ) && newRoute.updateable ) {
 		promise = newRoute.update( newData );
 	} else {
 		promise = roadtrip.Promise.all([

--- a/src/roadtrip.js
+++ b/src/roadtrip.js
@@ -31,12 +31,12 @@ const roadtrip = {
 		return roadtrip;
 	},
 
-	start ( { fallback, dispatch } = {} ) {
+	start ( { fallback, dispatch, scrollRestoration } = {} ) {
 		const href = !fallback || routes.some( route => route.matches( location.href ) ) ?
 			location.href :
 			fallback;
 
-		_start();
+		_start({ scrollRestoration });
 
 		return roadtrip.goto( href, {
 			dispatch,
@@ -75,8 +75,10 @@ const roadtrip = {
 	}
 };
 
-function _start () {
+function _start ( { scrollRestoration = 'manual' } ) {
 	if ( window ) {
+		history.scrollRestoration = scrollRestoration;
+
 		watchLinks( href => roadtrip.goto( href ) );
 
 		// watch history

--- a/src/roadtrip.js
+++ b/src/roadtrip.js
@@ -31,10 +31,12 @@ const roadtrip = {
 		return roadtrip;
 	},
 
-	start ( options = {} ) {
-		const href = routes.some( route => route.matches( location.href ) ) ?
+	start ( { fallback } = {} ) {
+		const href = !fallback || routes.some( route => route.matches( location.href ) ) ?
 			location.href :
-			options.fallback;
+			fallback;
+
+		_start();
 
 		return roadtrip.goto( href, {
 			replaceState: true,
@@ -72,26 +74,28 @@ const roadtrip = {
 	}
 };
 
-if ( window ) {
-	watchLinks( href => roadtrip.goto( href ) );
+function _start () {
+	if ( window ) {
+		watchLinks( href => roadtrip.goto( href ) );
 
-	// watch history
-	window.addEventListener( 'popstate', event => {
-		if ( !event.state ) return; // hashchange, or otherwise outside roadtrip's control
-		const scroll = scrollHistory[ event.state.uid ];
+		// watch history
+		window.addEventListener( 'popstate', event => {
+			if ( !event.state ) return; // hashchange, or otherwise outside roadtrip's control
+			const scroll = scrollHistory[ event.state.uid ];
 
-		_target = {
-			href: location.href,
-			scrollX: scroll.x,
-			scrollY: scroll.y,
-			popstate: true, // so we know not to manipulate the history
-			fulfil: noop,
-			reject: noop
-		};
+			_target = {
+				href: location.href,
+				scrollX: scroll.x,
+				scrollY: scroll.y,
+				popstate: true, // so we know not to manipulate the history
+				fulfil: noop,
+				reject: noop
+			};
 
-		_goto( _target );
-		currentID = event.state.uid;
-	}, false );
+			_goto( _target );
+			currentID = event.state.uid;
+		}, false );
+	}
 }
 
 function _goto ( target ) {

--- a/test/tests.js
+++ b/test/tests.js
@@ -265,8 +265,7 @@ describe( 'roadtrip', () => {
 					})
 					.start();
 
-				return roadtrip.start()
-					.then( () => roadtrip.goto( '/foo#baz' ) )
+				return roadtrip.goto( '/foo#baz' )
 					.then( () => {
 						assert.deepEqual( hashes, [
 							'bar',

--- a/test/tests.js
+++ b/test/tests.js
@@ -67,6 +67,23 @@ describe( 'roadtrip', () => {
 			});
 		});
 
+		it( 'does not navigate to the current route if dispatch is false', () => {
+			createTestEnvironment().then( window => {
+				const roadtrip = window.roadtrip;
+
+				return roadtrip
+					.add( '/', {
+						enter () {
+							assert.fail( 'should not dispatch initial route' );
+						}
+					})
+					.start({ dispatch: false })
+					.then( () => {
+						window.close();
+					});
+			});
+		});
+
 		it( 'returns a promise that resolves once the route transition completes', () => {
 			return createTestEnvironment().then( window => {
 				const roadtrip = window.roadtrip;


### PR DESCRIPTION
These commits change `start()` a bit:

- Only start listening for events after start was called. This should help users not to forget to call it (eg. #10), as leaving it out will cause some subtle bugs (eg. missing the first route's scroll position).

- Add a `dispatch` option, which doesn't dispatch the current routes' handlers.

    Related to the previous point. Useful for SSRed apps. Alternative for checking `isInitial` on every route. On the name: I just saw it used on a few libraries before.

- Set `scrollRestoration` to `manual` by default.

_ps. Sorry for the dump! All these PRs are obviously debatable; just let me know if anything doesn't work for you. Hopefully we can get at least #20 merged, since we can't handle even SSRed 404s right now._